### PR TITLE
changed the BlockItemMixin injection point to before stack decrement

### DIFF
--- a/src/main/java/ru/nern/notsoshadowextras/mixin/additions/BlockItemMixin.java
+++ b/src/main/java/ru/nern/notsoshadowextras/mixin/additions/BlockItemMixin.java
@@ -20,7 +20,7 @@ import java.util.Optional;
 @Mixin(BlockItem.class)
 public class BlockItemMixin {
     // Swapping the block entity of a newly placed block if there is StoredBlockEntityTag(for /nsse swap to work)
-    @Inject(method = "place(Lnet/minecraft/item/ItemPlacementContext;)Lnet/minecraft/util/ActionResult;", at = @At("RETURN"))
+    @Inject(method = "place(Lnet/minecraft/item/ItemPlacementContext;)Lnet/minecraft/util/ActionResult;", at = @At(value = "INVOKE", target = "Lnet/minecraft/item/ItemStack;decrementUnlessCreative(ILnet/minecraft/entity/LivingEntity;)V"))
     private void notsoshadowextras$swapBlockEntity(ItemPlacementContext context, CallbackInfoReturnable<ActionResult> cir) {
         ItemStack stack = context.getStack();
         if(context.getWorld().isClient || !stack.getComponents().contains(DataComponentTypes.CUSTOM_DATA)) return;


### PR DESCRIPTION
In survival items that were modified with the nsse swap command couldn't work if their count was one because by the time the custom data was checked the player was holding air. With this it should check before using up the item.