### PR TITLE
Fixed a crash when enabling HideStackTrace while not in a dev environment.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,16 +15,17 @@ jobs:
           21,    # Current Java LTS & minimum supported by Minecraft
         ]
         # and run on both Linux and Windows
-        os: [ubuntu-20.04, windows-2022]
+        os: [ubuntu-latest, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v3
       - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: ${{ matrix.java }}
       - name: make gradle wrapper executable
         if: ${{ runner.os != 'Windows' }}

--- a/src/main/java/ru/nern/notsoshadowextras/NSSECommands.java
+++ b/src/main/java/ru/nern/notsoshadowextras/NSSECommands.java
@@ -61,7 +61,7 @@ public class NSSECommands {
                     Text.literal("Block entity does not exist at this position"), false);
         }else{
             source.sendFeedback(() ->
-                    Text.literal(String.format("Block entity does exist. Type: %s", blockEntity.getType().getRegistryEntry().getIdAsString())), false);
+                    Text.literal(String.format("Block entity does exist. Type: %s", Registries.BLOCK_ENTITY_TYPE.getId(blockEntity.getType()))), false);
         }
 
         return 1;
@@ -90,7 +90,7 @@ public class NSSECommands {
         });
         if(blockEntity.isEmpty()) throw UNKNOWN_TYPE.create();
         if(current != null) world.removeBlockEntity(pos);
-        System.out.println("ADDING BLLOCK ENTITY: " + blockEntity.get());
+        System.out.println("ADDING BLOCK ENTITY: " + blockEntity.get());
         world.addBlockEntity(blockEntity.get());
     }
 

--- a/src/main/java/ru/nern/notsoshadowextras/mixin/additions/BlockItemMixin.java
+++ b/src/main/java/ru/nern/notsoshadowextras/mixin/additions/BlockItemMixin.java
@@ -1,6 +1,5 @@
 package ru.nern.notsoshadowextras.mixin.additions;
 
-import net.minecraft.block.Block;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.component.DataComponentTypes;
 import net.minecraft.item.BlockItem;

--- a/src/main/java/ru/nern/notsoshadowextras/mixin/update_suppression/ServerCrashSafePLMixin_HideST.java
+++ b/src/main/java/ru/nern/notsoshadowextras/mixin/update_suppression/ServerCrashSafePLMixin_HideST.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 @Mixin(ServerCrashSafePacketListener.class)
 public interface ServerCrashSafePLMixin_HideST {
     @WrapWithCondition(method = "onPacketException",
-            at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V"), remap = false)
+            at = @At(value = "INVOKE", target = "Lorg/slf4j/Logger;error(Ljava/lang/String;Ljava/lang/Object;Ljava/lang/Object;)V"))
     private boolean notsoshadowextras$hideStackTrace(Logger instance, String string, Object o, Object o2) {
         return false;
     }

--- a/src/main/java/ru/nern/notsoshadowextras/mixin/update_suppression/crash_fix/MinecraftServerMixin_CrashFix.java
+++ b/src/main/java/ru/nern/notsoshadowextras/mixin/update_suppression/crash_fix/MinecraftServerMixin_CrashFix.java
@@ -2,25 +2,16 @@ package ru.nern.notsoshadowextras.mixin.update_suppression.crash_fix;
 
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
-import com.mojang.datafixers.DataFix;
-import net.minecraft.datafixer.fix.ChunkDeleteLightFix;
-import net.minecraft.network.packet.s2c.play.GameMessageS2CPacket;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.text.Text;
-import net.minecraft.util.Formatting;
 import net.minecraft.util.crash.CrashException;
 import org.slf4j.Logger;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import ru.nern.notsoshadowextras.NSSE;
 import ru.nern.notsoshadowextras.NSSEUtils;
-import ru.nern.notsoshadowextras.crash_fix.UpdateSuppressionReason;
 
 import java.util.function.BooleanSupplier;
 


### PR DESCRIPTION
By removing `remap = false` from ServerCrashSafePLMixin_HideST, because Logger is a part of Minecraft's codebase.
[Fixed linux build action not working](https://github.com/ForwarD-NerN/NotSoShadowExtras/commit/19c08b2ed86f1938cb4a299433dc0cd1d4eb4fdd)
[Replaced usage of a deprecated feature. Removed unused imports](https://github.com/ForwarD-NerN/NotSoShadowExtras/commit/56665b007f8b98358b22aa6b3f6ca2737d70123a)